### PR TITLE
Affected Issue(s): Tidy up CI/CD pipeline

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,7 +6,7 @@ name: Java CI with Maven
 on:
   push:
     branches: 
-      - '**' 
+      - master
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,14 +31,8 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
 
-      - name: Run tests
-        run: mvn -B clean test
-
-      - name: Run integration tests
-        run: mvn -B clean integration-test
-
       - name: Build WAR
-        run: mvn -B package
+        run: mvn -B clean package
 
       - name: Upload WAR
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
What this commit has achieved:
1. Changed `maven.yml` `build` job on all branches into only `master`
branch
2. Removed test steps for `publish.yml`, as tests already done when PR
to master